### PR TITLE
fixed typo "jinja2numpy" package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ setuptools.setup(
     install_requires=[
         "lxml",
         "pandas",
-        "jinja2" "numpy",
+        "jinja2",
+        "numpy",
         "requests",
         "xalpha==0.5.0",
         "pushbullet.py==0.11.0",


### PR DESCRIPTION
ERROR: No matching distribution found for jinja2numpy